### PR TITLE
Corrected the BatteryService Naming.

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ function RitualsAccessory(log, config) {
         .setCharacteristic(Characteristic.FirmwareRevision, this.version);
 
     if (this.model_version == '1.0') {
-        this.serviceBatt = new Service.BatteryService('Battery', 'AirFresher');
+        this.serviceBatt = new Service.Battery('Battery', 'AirFresher');
         this.serviceBatt
             .setCharacteristic(Characteristic.BatteryLevel, '100')
             .setCharacteristic(


### PR DESCRIPTION
This error usually comes from a Homebridge / HAP-NodeJS plugin (like a “Genie” garage plugin) using an outdated API.